### PR TITLE
Configuring for pure-python-without-pypy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.pyc
 *.pyo
 .coverage
+.coverage.*
 .installed.cfg
 .mr.developer.cfg
 .tox/
@@ -14,6 +15,7 @@ build/
 coverage.xml
 develop-eggs/
 dist/
+docs/_build
 eggs/
 htmlcov/
 lib/

--- a/.meta.cfg
+++ b/.meta.cfg
@@ -1,0 +1,7 @@
+# Generated from:
+# https://github.com/zopefoundation/meta/tree/master/config/pure-python-without-pypy
+[meta]
+template = pure-python-without-pypy
+commit-id = 6c798e41c2fdc1412e936633616dbae1004f72a8
+fail-under = 98
+

--- a/.meta.cfg
+++ b/.meta.cfg
@@ -2,6 +2,6 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python-without-pypy
 [meta]
 template = pure-python-without-pypy
-commit-id = 6c798e41c2fdc1412e936633616dbae1004f72a8
+commit-id = c870dbdd2ae84f4df9d3b45abe3eee9660d1b37e
 fail-under = 98
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,11 @@ include tox.ini
 
 exclude MANIFEST.in
 
+recursive-include docs *.bat
+recursive-include docs *.py
+recursive-include docs *.rst
+recursive-include docs Makefile
+
 recursive-include src *.pt
 recursive-include src *.rst
 recursive-include src *.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,5 +8,6 @@ doctests = 1
 
 [check-manifest]
 ignore =
-    .travis.yml
     .editorconfig
+    .meta.cfg
+    .travis.yml

--- a/tox.ini
+++ b/tox.ini
@@ -24,22 +24,26 @@ skip_install = true
 deps =
     flake8
     check-manifest
+    check-python-versions
 commands =
     flake8 src setup.py
     check-manifest
+    check-python-versions .
 
 [testenv:coverage]
 basepython = python3
 deps =
     coverage
+    coverage-python-version
     zope.testrunner
 commands =
     coverage run -m zope.testrunner --test-path=src []
     coverage html
-    coverage report -m
+    coverage report -m --fail-under=98
 
 [coverage:run]
 branch = True
+plugins = coverage_python_version
 source = src
 
 [coverage:report]


### PR DESCRIPTION
In this iteration the required coverage can be configured in the `.meta.cfg`.